### PR TITLE
Improve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ ENV/
 /*.csv
 !examples/*.csv
 *.db
+
+# Mac metadata
+.DS_Store
+

--- a/nemreader/nem_objects.py
+++ b/nemreader/nem_objects.py
@@ -1,9 +1,6 @@
 from datetime import datetime
 from typing import Dict, List, NamedTuple, Optional
 
-from pydantic import BaseModel
-
-
 class HeaderRecord(NamedTuple):
     """Header record (100)"""
 
@@ -112,43 +109,30 @@ class B2BDetails13(NamedTuple):
     current_trans_code: str
     current_ret_service_order: str
 
-# Structure Dict as a pydantic.BaseModel
-# to avoid time-consuming re-validation of readings
-class Readings(BaseModel):
-    __root__: Dict[str, Dict[str, List[Reading]]]
-
-    # expose standard dictionary methods
-    def __getitem__(self, key):
-        return self.__root__.__getitem__(key)
-
-    def __len__(self):
-        return self.__root__.__len__()
-
-    def __contains__(self, item):
-        return self.__root__.__contains__(item)
-
-    def items(self):
-        return self.__root__.items()
-
-    def keys(self):
-        return self.__root__.keys()
-
-
-class NEMReadings(BaseModel):
+class NEMReadings:
     """Represents a meter reading"""
 
-    readings: Readings
+    readings: Dict[str, Dict[str, List[Reading]]]
     transactions: Dict[str, Dict[str, list]]
+
+    def __init__(self, readings, transactions):
+        self.readings = readings
+        self.transactions = transactions
 
     class Config:
         copy_on_model_validation = 'shallow' # faster
 
-class NEMData(BaseModel):
+class NEMData:
     """Represents a meter reading"""
 
     header: HeaderRecord
-    readings: Readings
+    readings: Dict[str, Dict[str, List[Reading]]]
     transactions: Dict[str, Dict[str, list]]
+
+    def __init__(self, header, readings, transactions):
+        self.header = header
+        self.readings = readings
+        self.transactions = transactions
 
     @property
     def nmis(self) -> List[str]:

--- a/nemreader/nem_objects.py
+++ b/nemreader/nem_objects.py
@@ -112,21 +112,47 @@ class B2BDetails13(NamedTuple):
     current_trans_code: str
     current_ret_service_order: str
 
+# Structure Dict as a pydantic.BaseModel
+# to avoid time-consuming re-validation of readings
+class Readings(BaseModel):
+    __root__: Dict[str, Dict[str, List[Reading]]]
+
+    # expose standard dictionary methods
+    def __getitem__(self, key):
+        return self.__root__.__getitem__(key)
+
+    def __len__(self):
+        return self.__root__.__len__()
+
+    def __contains__(self, item):
+        return self.__root__.__contains__(item)
+
+    def items(self):
+        return self.__root__.items()
+
+    def keys(self):
+        return self.__root__.keys()
+
 
 class NEMReadings(BaseModel):
     """Represents a meter reading"""
 
-    readings: Dict[str, Dict[str, List[Reading]]]
+    readings: Readings
     transactions: Dict[str, Dict[str, list]]
 
+    class Config:
+        copy_on_model_validation = 'shallow' # faster
 
 class NEMData(BaseModel):
     """Represents a meter reading"""
 
     header: HeaderRecord
-    readings: Dict[str, Dict[str, List[Reading]]]
+    readings: Readings
     transactions: Dict[str, Dict[str, list]]
 
     @property
     def nmis(self) -> List[str]:
         return list(self.transactions.keys())
+
+    class Config:
+        copy_on_model_validation = 'shallow' # faster

--- a/nemreader/nem_reader.py
+++ b/nemreader/nem_reader.py
@@ -94,28 +94,28 @@ class NEMFile:
                     # Zip file is open in binary mode
                     # So decode then convert back to list
                     nmi_file = csv_text.read().decode("utf-8").splitlines()
-                    reads = self.parse_nem_file(nmi_file, file_name=csv_file)
-                    for nmi in reads.transactions.keys():
-                        self.nmis.add(nmi)
-                        suffixes = list(reads.transactions[nmi].keys())
-                        self.nmi_channels[nmi] = suffixes
-                    return NEMData(
-                        header=self.header,
-                        readings=reads.readings,
-                        transactions=reads.transactions,
-                    )
+                reads = self.parse_nem_file(nmi_file, file_name=csv_file)
+                for nmi in reads.transactions.keys():
+                    self.nmis.add(nmi)
+                    suffixes = list(reads.transactions[nmi].keys())
+                    self.nmi_channels[nmi] = suffixes
+                return NEMData(
+                    header=self.header,
+                    readings=reads.readings,
+                    transactions=reads.transactions,
+                )
 
         with open(self.file_path) as nmi_file:
             reads = self.parse_nem_file(nmi_file)
-            for nmi in reads.transactions.keys():
-                self.nmis.add(nmi)
-                suffixes = list(reads.transactions[nmi].keys())
-                self.nmi_channels[nmi] = suffixes
-            return NEMData(
-                header=self.header,
-                readings=reads.readings,
-                transactions=reads.transactions,
-            )
+        for nmi in reads.transactions.keys():
+            self.nmis.add(nmi)
+            suffixes = list(reads.transactions[nmi].keys())
+            self.nmi_channels[nmi] = suffixes
+        return NEMData(
+            header=self.header,
+            readings=reads.readings,
+            transactions=reads.transactions,
+        )
 
     def get_data_frame(
         self, split_days: bool = False, set_interval: Optional[int] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 keywords = ["energy", "NEM12", "NEM13"]
 requires-python = ">=3.8"
 dynamic = ["version", "description"]
-dependencies = ["pandas", "pydantic", "sqlite_utils", "typer"]
+dependencies = ["pandas", "sqlite_utils", "typer"]
 
 [project.optional-dependencies]
 test = ["pytest >=2.7.3", "pytest-cov", "mypy"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,8 +58,6 @@ pluggy==1.0.0
     # via pytest
 pycodestyle==2.10.0
     # via flake8
-pydantic==1.10.2
-    # via nemreader (pyproject.toml)
 pyflakes==3.0.1
     # via flake8
 pytest==7.2.0
@@ -91,6 +89,4 @@ tomli==2.0.1
 typer==0.7.0
     # via nemreader (pyproject.toml)
 typing-extensions==4.4.0
-    # via
-    #   mypy
-    #   pydantic
+    # via mypy


### PR DESCRIPTION
Somewhat fixes #35 .

The main change here is to factor out the dictionary of readings into a `pydantic.BaseModel`. This means we don't re-validate it as we pass it around into multiple parent classes. I had to write some repetative methods that just expose the methods of `__root__`.

The downsize of this approach is that the `readings` attribute is no longer a literal dictionary, even though it should still be usable with the same methods as a dictionary. I don't know if that's a backwards incompatable change?

The `copy_on_model_validation` was a slight speedup. This skips copying of the data, but validation is still done.

