### PR TITLE
Handle WP NEM12 edge-case with missing MSATSLoadDateTime col

### DIFF
--- a/nemreader/nem_reader.py
+++ b/nemreader/nem_reader.py
@@ -500,17 +500,20 @@ def parse_300_row(
     QualityMethod,ReasonCode,ReasonDescription,UpdateDateTime,MSATSLoadDateTime
     Example: 300,20030501,50.1, . . . ,21.5,V,,,20030101153445,20030102023012
     """
-    num_non_reading_fields = (
-        7  # count of fields except IntervalValue1 . . . IntervalValueN
-    )
+
+    # count of fields except IntervalValue1 . . . IntervalValueN
+    # excluding MSATSLoadDateTime which is only required if present
+    num_required_non_reading_fields = 6
 
     num_intervals = int(minutes_per_day / interval)
 
     interval_date = parse_datetime(row[1])
     last_interval = 2 + num_intervals
-    if len(row) != num_intervals + num_non_reading_fields:
+    if len(row) < num_intervals + num_required_non_reading_fields:
+        num_rows = len(row) - num_required_non_reading_fields
         raise ValueError(
-            f"Unexpected number of values in 300 row: {len(row)-num_non_reading_fields} readings for {interval}min intervals"
+            f"Unexpected number of values in 300 row: " +
+            f"{num_rows} readings for {interval}min intervals"
         )
     quality_method = row[last_interval]
 


### PR DESCRIPTION
Western Power NEM12 files don't always include an empty column for MSATSLoadDateTime if it is never present, instead the column can be completely absent.

This occurs with files downloaded from their internal portal and causes a ValueError exception to be unnecessarily raised on parse, as the number of columns is less than expected.

The AEMO _[Meter Data File Format Specification NEM12 & NEM13](https://aemo.com.au/-/media/files/electricity/nem/retail_and_metering/metering-procedures/2017/mdff_specification_nem12_nem13_final_v102.pdf)_ states that MSATSLoadDateTime is required if available, but is not mandatory.

As such, instead of erroring when the final MSATSLoadDateTime column isn't present, we can proceed and fill it with None with no consequences.

Validation for parse_300_row has been modified to ensure that the error is only raised if number of required non-reading fields is less than 6, instead of equals 7.

These WP NEM12 files otherwise seem to parse fine with this change.